### PR TITLE
Fix CI failure: Configuration Cache and Formatting

### DIFF
--- a/lint-logic/spotless/src/main/kotlin/net.yewton.petclinic.spotless.gradle.kts
+++ b/lint-logic/spotless/src/main/kotlin/net.yewton.petclinic.spotless.gradle.kts
@@ -11,18 +11,6 @@ val editorConfigPath = listOf(
 ).map { it.toPath().resolve(".editorconfig") }
   .firstOrNull { it.toFile().exists() }
 
-tasks.withType<SpotlessTask> {
-  doFirst {
-    logger.warn("editorconfig = ${editorConfigPath?.toFile()?.absolutePath}")
-  }
-}
-
-// net.yewton.petclinic.root-project.gradle.kts と同様に、
-// ルートからサブプロジェクトの spotlessApply を呼び出せるようにする。
-tasks.named("spotlessApply") {
-  dependsOn(subprojects.flatMap { it.tasks.named { taskName -> taskName == "spotlessApply" } })
-}
-
 spotless {
   pluginManager.withPlugin("kotlin") {
     kotlin {

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/visit/VisitController.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/visit/VisitController.kt
@@ -1,5 +1,6 @@
 package net.yewton.petclinic.visit
 
+import jakarta.validation.Valid
 import net.yewton.petclinic.owner.OwnerRepository
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -9,46 +10,45 @@ import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
-import jakarta.validation.Valid
 
 @Controller
 @RequestMapping("/owners/{ownerId}")
 class VisitController(
-    private val visits: VisitRepository,
-    private val owners: OwnerRepository,
+  private val visits: VisitRepository,
+  private val owners: OwnerRepository,
 ) {
-    @GetMapping("/pets/{petId}/visits/new")
-    suspend fun initNewVisitForm(
-        @PathVariable ownerId: Int,
-        @PathVariable petId: Int,
-        model: Model,
-    ): String {
-        val owner = owners.findById(ownerId)
-        val pet = owner?.pets?.find { it.id == petId } ?: throw IllegalArgumentException("Pet not found")
-        model.addAttribute("owner", owner)
-        model.addAttribute("pet", pet)
-        model.addAttribute("visit", Visit(null, null, null))
-        return "pets/createOrUpdateVisitForm"
+  @GetMapping("/pets/{petId}/visits/new")
+  suspend fun initNewVisitForm(
+    @PathVariable ownerId: Int,
+    @PathVariable petId: Int,
+    model: Model,
+  ): String {
+    val owner = owners.findById(ownerId)
+    val pet = owner?.pets?.find { it.id == petId } ?: throw IllegalArgumentException("Pet not found")
+    model.addAttribute("owner", owner)
+    model.addAttribute("pet", pet)
+    model.addAttribute("visit", Visit(null, null, null))
+    return "pets/createOrUpdateVisitForm"
+  }
+
+  @PostMapping("/pets/{petId}/visits/new")
+  suspend fun processNewVisitForm(
+    @PathVariable ownerId: Int,
+    @PathVariable petId: Int,
+    @Valid @ModelAttribute visit: Visit,
+    result: BindingResult,
+    model: Model,
+  ): String {
+    val owner = owners.findById(ownerId)
+    val pet = owner?.pets?.find { it.id == petId } ?: throw IllegalArgumentException("Pet not found")
+
+    if (result.hasErrors()) {
+      model.addAttribute("owner", owner)
+      model.addAttribute("pet", pet)
+      return "pets/createOrUpdateVisitForm"
     }
 
-    @PostMapping("/pets/{petId}/visits/new")
-    suspend fun processNewVisitForm(
-        @PathVariable ownerId: Int,
-        @PathVariable petId: Int,
-        @Valid @ModelAttribute visit: Visit,
-        result: BindingResult,
-        model: Model,
-    ): String {
-        val owner = owners.findById(ownerId)
-        val pet = owner?.pets?.find { it.id == petId } ?: throw IllegalArgumentException("Pet not found")
-
-        if (result.hasErrors()) {
-            model.addAttribute("owner", owner)
-            model.addAttribute("pet", pet)
-            return "pets/createOrUpdateVisitForm"
-        }
-
-        visits.save(visit, petId)
-        return "redirect:/owners/$ownerId"
-    }
+    visits.save(visit, petId)
+    return "redirect:/owners/$ownerId"
+  }
 }

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/visit/VisitRepository.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/visit/VisitRepository.kt
@@ -8,31 +8,31 @@ import org.springframework.transaction.annotation.Transactional
 
 @Component
 class VisitRepository(
-    private val create: DSLContext,
+  private val create: DSLContext,
 ) {
-    @Transactional
-    suspend fun save(
-        visit: Visit,
-        petId: Int,
-    ): Visit {
-        if (visit.id == null) {
-            val newId =
-                create
-                    .insertInto(VISITS)
-                    .columns(VISITS.VISIT_DATE, VISITS.DESCRIPTION, VISITS.PET_ID)
-                    .values(visit.date, visit.description, petId)
-                    .returningResult(VISITS.ID)
-                    .awaitSingle()
-                    .value1()
-            return visit.copy(id = newId)
-        } else {
-            create
-                .update(VISITS)
-                .set(VISITS.VISIT_DATE, visit.date)
-                .set(VISITS.DESCRIPTION, visit.description)
-                .where(VISITS.ID.eq(visit.id))
-                .awaitSingle()
-            return visit
-        }
+  @Transactional
+  suspend fun save(
+    visit: Visit,
+    petId: Int,
+  ): Visit {
+    if (visit.id == null) {
+      val newId =
+        create
+          .insertInto(VISITS)
+          .columns(VISITS.VISIT_DATE, VISITS.DESCRIPTION, VISITS.PET_ID)
+          .values(visit.date, visit.description, petId)
+          .returningResult(VISITS.ID)
+          .awaitSingle()
+          .value1()
+      return visit.copy(id = newId)
+    } else {
+      create
+        .update(VISITS)
+        .set(VISITS.VISIT_DATE, visit.date)
+        .set(VISITS.DESCRIPTION, visit.description)
+        .where(VISITS.ID.eq(visit.id))
+        .awaitSingle()
+      return visit
     }
+  }
 }

--- a/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/pet/PetControllerIntegrationTests.kt
+++ b/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/pet/PetControllerIntegrationTests.kt
@@ -13,47 +13,47 @@ import org.springframework.util.LinkedMultiValueMap
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class PetControllerIntegrationTests(
-    @Autowired private val webTestClient: WebTestClient,
-    @Autowired private val ownerRepository: OwnerRepository,
+  @Autowired private val webTestClient: WebTestClient,
+  @Autowired private val ownerRepository: OwnerRepository,
 ) {
-    @Test
-    fun `should show update pet form`() {
-        webTestClient
-            .get()
-            .uri("/owners/1/pets/1/edit")
-            .accept(MediaType.TEXT_HTML)
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody<String>()
-            .value { body ->
-                assertThat(body).contains("Update Pet")
-            }
+  @Test
+  fun `should show update pet form`() {
+    webTestClient
+      .get()
+      .uri("/owners/1/pets/1/edit")
+      .accept(MediaType.TEXT_HTML)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody<String>()
+      .value { body ->
+        assertThat(body).contains("Update Pet")
+      }
+  }
+
+  @Test
+  fun `should process update pet form`() =
+    runTest {
+      val petData = LinkedMultiValueMap<String, String>()
+      petData.add("name", "Leo-Updated")
+      petData.add("birthDate", "2000-09-07")
+      petData.add("type", "cat")
+
+      webTestClient
+        .post()
+        .uri("/owners/1/pets/1/edit")
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        .bodyValue(petData)
+        .exchange()
+        .expectStatus()
+        .is3xxRedirection
+        .expectHeader()
+        .valueEquals("Location", "/owners/1")
+
+      val owner = ownerRepository.findById(1)
+      val updatedPet = owner?.pets?.find { it.id == 1 }
+
+      assertThat(updatedPet).isNotNull
+      assertThat(updatedPet!!.name).isEqualTo("Leo-Updated")
     }
-
-    @Test
-    fun `should process update pet form`() =
-        runTest {
-            val petData = LinkedMultiValueMap<String, String>()
-            petData.add("name", "Leo-Updated")
-            petData.add("birthDate", "2000-09-07")
-            petData.add("type", "cat")
-
-            webTestClient
-                .post()
-                .uri("/owners/1/pets/1/edit")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .bodyValue(petData)
-                .exchange()
-                .expectStatus()
-                .is3xxRedirection
-                .expectHeader()
-                .valueEquals("Location", "/owners/1")
-
-            val owner = ownerRepository.findById(1)
-            val updatedPet = owner?.pets?.find { it.id == 1 }
-
-            assertThat(updatedPet).isNotNull
-            assertThat(updatedPet!!.name).isEqualTo("Leo-Updated")
-        }
 }

--- a/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/visit/VisitControllerIntegrationTests.kt
+++ b/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/visit/VisitControllerIntegrationTests.kt
@@ -13,48 +13,48 @@ import org.springframework.util.LinkedMultiValueMap
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class VisitControllerIntegrationTests(
-    @Autowired private val webTestClient: WebTestClient,
-    @Autowired private val ownerRepository: OwnerRepository,
+  @Autowired private val webTestClient: WebTestClient,
+  @Autowired private val ownerRepository: OwnerRepository,
 ) {
-    @Test
-    fun `should show new visit form`() {
-        webTestClient
-            .get()
-            .uri("/owners/1/pets/1/visits/new")
-            .accept(MediaType.TEXT_HTML)
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody<String>()
-            .value { body ->
-                assertThat(body).contains("Visit")
-                assertThat(body).contains("Add Visit")
-            }
+  @Test
+  fun `should show new visit form`() {
+    webTestClient
+      .get()
+      .uri("/owners/1/pets/1/visits/new")
+      .accept(MediaType.TEXT_HTML)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody<String>()
+      .value { body ->
+        assertThat(body).contains("Visit")
+        assertThat(body).contains("Add Visit")
+      }
+  }
+
+  @Test
+  fun `should process new visit form`() =
+    runTest {
+      val visitData = LinkedMultiValueMap<String, String>()
+      visitData.add("date", "2024-01-01")
+      visitData.add("description", "Rabies shot")
+
+      webTestClient
+        .post()
+        .uri("/owners/1/pets/1/visits/new")
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        .bodyValue(visitData)
+        .exchange()
+        .expectStatus()
+        .is3xxRedirection
+        .expectHeader()
+        .valueEquals("Location", "/owners/1")
+
+      val owner = ownerRepository.findById(1)
+      val pet = owner?.pets?.find { it.id == 1 }
+      val visit = pet?.visits?.find { it.description == "Rabies shot" }
+
+      assertThat(visit).isNotNull
+      assertThat(visit!!.date.toString()).isEqualTo("2024-01-01")
     }
-
-    @Test
-    fun `should process new visit form`() =
-        runTest {
-            val visitData = LinkedMultiValueMap<String, String>()
-            visitData.add("date", "2024-01-01")
-            visitData.add("description", "Rabies shot")
-
-            webTestClient
-                .post()
-                .uri("/owners/1/pets/1/visits/new")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .bodyValue(visitData)
-                .exchange()
-                .expectStatus()
-                .is3xxRedirection
-                .expectHeader()
-                .valueEquals("Location", "/owners/1")
-
-            val owner = ownerRepository.findById(1)
-            val pet = owner?.pets?.find { it.id == 1 }
-            val visit = pet?.visits?.find { it.description == "Rabies shot" }
-
-            assertThat(visit).isNotNull
-            assertThat(visit!!.date.toString()).isEqualTo("2024-01-01")
-        }
 }


### PR DESCRIPTION
Fixed the CI failure by resolving two main issues:
1. **Configuration Cache Issues**: The `spotless` configuration in `lint-logic` was capturing non-serializable objects (like `Project`) inside a `doFirst` block and using `subprojects` in a way that is incompatible with the configuration cache in a composite build. I removed the `doFirst` logging and the redundant `spotlessApply` task dependency.
2. **Formatting Violations**: Multiple files had indentation and import order violations. I ran `./gradlew spotlessApply` to bring the codebase into compliance with the project's `.editorconfig` (enforced by `ktlint` via `Spotless`).

After these changes, the Gradle configuration phase passes successfully, and the configuration cache entry is stored. The formatting check (`spotlessCheck`) also passes. Integration tests still fail in the local sandbox due to the lack of a Docker environment for Testcontainers, but the CI-specific issues have been resolved.

---
*PR created automatically by Jules for task [1682130240345763185](https://jules.google.com/task/1682130240345763185) started by @yewton*