### PR TITLE
Implement visit edit functionality to resolve #79

### DIFF
--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/visit/VisitController.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/visit/VisitController.kt
@@ -51,4 +51,42 @@ class VisitController(
     visits.save(visit, petId)
     return "redirect:/owners/$ownerId"
   }
+
+  @GetMapping("/pets/{petId}/visits/{visitId}/edit")
+  suspend fun initEditVisitForm(
+    @PathVariable ownerId: Int,
+    @PathVariable petId: Int,
+    @PathVariable visitId: Int,
+    model: Model,
+  ): String {
+    val owner = owners.findById(ownerId)
+    val pet = owner?.pets?.find { it.id == petId } ?: throw IllegalArgumentException("Pet not found")
+    val visit = pet.visits.find { it.id == visitId } ?: throw IllegalArgumentException("Visit not found")
+    model.addAttribute("owner", owner)
+    model.addAttribute("pet", pet)
+    model.addAttribute("visit", visit)
+    return "pets/createOrUpdateVisitForm"
+  }
+
+  @PostMapping("/pets/{petId}/visits/{visitId}/edit")
+  suspend fun processEditVisitForm(
+    @PathVariable ownerId: Int,
+    @PathVariable petId: Int,
+    @PathVariable visitId: Int,
+    @Valid @ModelAttribute visit: Visit,
+    result: BindingResult,
+    model: Model,
+  ): String {
+    val owner = owners.findById(ownerId)
+    val pet = owner?.pets?.find { it.id == petId } ?: throw IllegalArgumentException("Pet not found")
+
+    if (result.hasErrors()) {
+      model.addAttribute("owner", owner)
+      model.addAttribute("pet", pet)
+      return "pets/createOrUpdateVisitForm"
+    }
+
+    visits.save(visit.copy(id = visitId), petId)
+    return "redirect:/owners/$ownerId"
+  }
 }

--- a/petclinic-fullstack/app/src/main/resources/templates/owners/ownerDetails.html
+++ b/petclinic-fullstack/app/src/main/resources/templates/owners/ownerDetails.html
@@ -73,6 +73,7 @@
             <tr th:each="visit : ${pet.visits}">
               <td th:text="${#temporals.format(visit.date, 'yyyy-MM-dd')}"></td>
               <td th:text="${visit?.description}"></td>
+              <td><a th:href="@{__${owner.id}__/pets/__${pet.id}__/visits/__${visit.id}__/edit}">Edit Visit</a></td>
             </tr>
             <tr>
               <td><a th:href="@{__${owner.id}__/pets/__${pet.id}__/edit}">Edit Pet</a></td>

--- a/petclinic-fullstack/app/src/main/resources/templates/pets/createOrUpdateVisitForm.html
+++ b/petclinic-fullstack/app/src/main/resources/templates/pets/createOrUpdateVisitForm.html
@@ -51,9 +51,9 @@
       <th>Date</th>
       <th>Description</th>
     </tr>
-    <tr th:if="${!visit['new']}" th:each="visit : ${pet.visits}">
-      <td th:text="${#temporals.format(visit.date, 'yyyy-MM-dd')}"></td>
-      <td th:text=" ${visit.description}"></td>
+    <tr th:each="previousVisit : ${pet.visits}">
+      <td th:text="${#temporals.format(previousVisit.date, 'yyyy-MM-dd')}"></td>
+      <td th:text="${previousVisit.description}"></td>
     </tr>
   </table>
 

--- a/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/visit/VisitControllerIntegrationTests.kt
+++ b/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/visit/VisitControllerIntegrationTests.kt
@@ -57,4 +57,47 @@ class VisitControllerIntegrationTests(
       assertThat(visit).isNotNull
       assertThat(visit!!.date.toString()).isEqualTo("2024-01-01")
     }
+
+  @Test
+  fun `should show edit visit form`() {
+    // visit id=1 belongs to pet id=7, owner id=6
+    webTestClient
+      .get()
+      .uri("/owners/6/pets/7/visits/1/edit")
+      .accept(MediaType.TEXT_HTML)
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody<String>()
+      .value { body ->
+        assertThat(body).contains("Visit")
+        assertThat(body).contains("rabies shot")
+      }
+  }
+
+  @Test
+  fun `should process edit visit form`() =
+    runTest {
+      val visitData = LinkedMultiValueMap<String, String>()
+      visitData.add("date", "2010-03-04")
+      visitData.add("description", "Updated rabies shot")
+
+      webTestClient
+        .post()
+        .uri("/owners/6/pets/7/visits/1/edit")
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        .bodyValue(visitData)
+        .exchange()
+        .expectStatus()
+        .is3xxRedirection
+        .expectHeader()
+        .valueEquals("Location", "/owners/6")
+
+      val owner = ownerRepository.findById(6)
+      val pet = owner?.pets?.find { it.id == 7 }
+      val visit = pet?.visits?.find { it.id == 1 }
+
+      assertThat(visit).isNotNull
+      assertThat(visit!!.description).isEqualTo("Updated rabies shot")
+    }
 }

--- a/petclinic-fullstack/app/src/test/resources/docker-java.properties
+++ b/petclinic-fullstack/app/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.41


### PR DESCRIPTION
- Add GET/POST endpoints for editing existing visits at
  /owners/{ownerId}/pets/{petId}/visits/{visitId}/edit
- Fix createOrUpdateVisitForm.html to always show previous visits
  (was previously hidden on new visit form due to th:if condition)
- Add "Edit Visit" links in ownerDetails.html for each visit row
- Add integration tests for show/process edit visit form
- Add docker-java.properties to pin Docker API version to 1.41,
  fixing test compatibility with Docker 25+ (which dropped support
  for API versions below 1.40, while Testcontainers 1.21.3 fell
  back to 1.32 by default)

https://claude.ai/code/session_012QxgJar3JRUQxpqarUyJCx