### PR TITLE
Implement pet type management (list, create, edit, delete)

### DIFF
--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/owner/OwnerRepository.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/owner/OwnerRepository.kt
@@ -42,7 +42,7 @@ class OwnerRepository(
         OWNERS.pets.ID,
         OWNERS.pets.NAME,
         OWNERS.pets.BIRTH_DATE,
-        row(OWNERS.pets.types_.NAME).mapping { PetType(it) },
+        row(OWNERS.pets.types_.ID, OWNERS.pets.types_.NAME).mapping { id, name -> PetType(id, name) },
         visits(),
       ).from(OWNERS.pets),
     ).intoList { Pet(it[PETS.ID], it[PETS.NAME], it[PETS.BIRTH_DATE], it.value4(), it.value5().toSet()) }

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetController.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetController.kt
@@ -28,7 +28,7 @@ class PetController(
     val owner = owners.findById(ownerId)
     val types = petTypes.findAll()
     model.addAttribute("owner", owner)
-    model.addAttribute("pet", Pet(null, "", null, PetType("cat"), hashSetOf()))
+    model.addAttribute("pet", Pet(null, "", null, PetType(name = "cat"), hashSetOf()))
     model.addAttribute("types", types)
     return "pets/createOrUpdatePetForm"
   }

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetType.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetType.kt
@@ -1,7 +1,13 @@
 package net.yewton.petclinic.pet
 
+import jakarta.validation.constraints.NotBlank
+
 data class PetType(
-  val name: String?,
+  val id: Int? = null,
+  @field:NotBlank
+  val name: String? = null,
 ) {
   override fun toString(): String = name ?: ""
+
+  fun isNew(): Boolean = id == null
 }

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetTypeController.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetTypeController.kt
@@ -1,0 +1,78 @@
+package net.yewton.petclinic.pet
+
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.validation.BindingResult
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.server.ResponseStatusException
+
+@Controller
+@RequestMapping("/pettypes")
+class PetTypeController(
+  private val petTypes: PetTypeRepository,
+) {
+  @GetMapping
+  suspend fun list(model: Model): String {
+    model.addAttribute("petTypes", petTypes.findAll())
+    return "pettypes/petTypeList"
+  }
+
+  @GetMapping("/new")
+  fun initCreationForm(model: Model): String {
+    model.addAttribute("petType", PetType())
+    return "pettypes/createOrUpdatePetTypeForm"
+  }
+
+  @PostMapping("/new")
+  suspend fun processCreationForm(
+    @Valid @ModelAttribute petType: PetType,
+    result: BindingResult,
+  ): String {
+    if (result.hasErrors()) {
+      return "pettypes/createOrUpdatePetTypeForm"
+    }
+    petTypes.save(petType)
+    return "redirect:/pettypes"
+  }
+
+  @GetMapping("/{petTypeId}/edit")
+  suspend fun initUpdateForm(
+    @PathVariable petTypeId: Int,
+    model: Model,
+  ): String {
+    val petType = petTypes.findById(petTypeId) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Pet type not found")
+    model.addAttribute("petType", petType)
+    return "pettypes/createOrUpdatePetTypeForm"
+  }
+
+  @PostMapping("/{petTypeId}/edit")
+  suspend fun processUpdateForm(
+    @PathVariable petTypeId: Int,
+    @Valid @ModelAttribute petType: PetType,
+    result: BindingResult,
+  ): String {
+    if (result.hasErrors()) {
+      return "pettypes/createOrUpdatePetTypeForm"
+    }
+    petTypes.save(petType.copy(id = petTypeId))
+    return "redirect:/pettypes"
+  }
+
+  @PostMapping("/{petTypeId}/delete")
+  suspend fun delete(
+    @PathVariable petTypeId: Int,
+  ): String {
+    petTypes.findById(petTypeId) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Pet type not found")
+    if (petTypes.isInUse(petTypeId)) {
+      throw ResponseStatusException(HttpStatus.CONFLICT, "Pet type is in use and cannot be deleted")
+    }
+    petTypes.delete(petTypeId)
+    return "redirect:/pettypes"
+  }
+}

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetTypeConverter.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetTypeConverter.kt
@@ -1,0 +1,9 @@
+package net.yewton.petclinic.pet
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.stereotype.Component
+
+@Component
+class PetTypeConverter : Converter<String, PetType> {
+  override fun convert(source: String): PetType = PetType(name = source)
+}

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetTypeRepository.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetTypeRepository.kt
@@ -3,6 +3,9 @@ package net.yewton.petclinic.pet
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.awaitSingle
+import net.yewton.petclinic.jooq.tables.references.PETS
 import net.yewton.petclinic.jooq.tables.references.TYPES
 import org.jooq.DSLContext
 import org.springframework.stereotype.Component
@@ -15,10 +18,58 @@ class PetTypeRepository(
   @Transactional(readOnly = true)
   suspend fun findAll(): List<PetType> =
     create
-      .select(TYPES.NAME)
+      .select(TYPES.ID, TYPES.NAME)
       .from(TYPES)
       .orderBy(TYPES.NAME)
       .asFlow()
-      .map { PetType(it[TYPES.NAME]) }
+      .map { PetType(it[TYPES.ID], it[TYPES.NAME]) }
       .toList()
+
+  @Transactional(readOnly = true)
+  suspend fun findById(id: Int): PetType? =
+    create
+      .select(TYPES.ID, TYPES.NAME)
+      .from(TYPES)
+      .where(TYPES.ID.eq(id))
+      .awaitFirstOrNull()
+      ?.let { PetType(it[TYPES.ID], it[TYPES.NAME]) }
+
+  @Transactional(readOnly = true)
+  suspend fun isInUse(id: Int): Boolean =
+    create
+      .selectCount()
+      .from(PETS)
+      .where(PETS.TYPE_ID.eq(id))
+      .awaitSingle()
+      .value1() > 0
+
+  @Transactional
+  suspend fun save(petType: PetType): PetType {
+    if (petType.isNew()) {
+      val newId =
+        create
+          .insertInto(TYPES)
+          .columns(TYPES.NAME)
+          .values(petType.name)
+          .returningResult(TYPES.ID)
+          .awaitSingle()
+          .value1()
+      return petType.copy(id = newId)
+    } else {
+      create
+        .update(TYPES)
+        .set(TYPES.NAME, petType.name)
+        .where(TYPES.ID.eq(petType.id))
+        .awaitSingle()
+      return petType
+    }
+  }
+
+  @Transactional
+  suspend fun delete(id: Int) {
+    create
+      .deleteFrom(TYPES)
+      .where(TYPES.ID.eq(id))
+      .awaitSingle()
+  }
 }

--- a/petclinic-fullstack/app/src/main/resources/templates/fragments/layout.html
+++ b/petclinic-fullstack/app/src/main/resources/templates/fragments/layout.html
@@ -70,6 +70,11 @@
             <span>Veterinarians</span>
           </li>
 
+          <li th:replace="~{::menuItem ('/pettypes','pettypes','manage pet types','th-list','Pet Types')}">
+            <span class="fa fa-th-list" aria-hidden="true"></span>
+            <span>Pet Types</span>
+          </li>
+
           <li
             th:replace="~{::menuItem ('/oups','error','trigger a RuntimeException to see how it is handled','exclamation-triangle','Error')}">
             <span class="fa exclamation-triangle" aria-hidden="true"></span>

--- a/petclinic-fullstack/app/src/main/resources/templates/pettypes/createOrUpdatePetTypeForm.html
+++ b/petclinic-fullstack/app/src/main/resources/templates/pettypes/createOrUpdatePetTypeForm.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+<html xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{fragments/layout :: layout (~{::body},'pettypes')}">
+
+<body>
+
+  <h2 th:if="${petType.new}">New Pet Type</h2>
+  <h2 th:unless="${petType.new}">Edit Pet Type</h2>
+
+  <form th:object="${petType}" class="form-horizontal" method="post"
+    th:action="${petType.new} ? @{/pettypes/new} : @{/pettypes/{id}/edit(id=${petType.id})}">
+    <div class="form-group has-feedback">
+      <input th:replace="~{fragments/inputField :: input ('Name', 'name', 'text')}" />
+    </div>
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-10">
+        <button
+          th:with="text=${petType['new']} ? 'Add Pet Type' : 'Update Pet Type'"
+          class="btn btn-primary" type="submit" th:text="${text}">Add Pet Type</button>
+      </div>
+    </div>
+  </form>
+
+</body>
+
+</html>

--- a/petclinic-fullstack/app/src/main/resources/templates/pettypes/petTypeList.html
+++ b/petclinic-fullstack/app/src/main/resources/templates/pettypes/petTypeList.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+
+<html xmlns:th="https://www.thymeleaf.org"
+  th:replace="~{fragments/layout :: layout (~{::body},'pettypes')}">
+
+<body>
+
+  <h2>Pet Types</h2>
+
+  <a th:href="@{/pettypes/new}" class="btn btn-primary">Add Pet Type</a>
+
+  <br />
+  <br />
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr th:each="petType : ${petTypes}">
+        <td th:text="${petType.name}"></td>
+        <td>
+          <a th:href="@{/pettypes/__${petType.id}__/edit}" class="btn btn-sm btn-primary">Edit</a>
+          <form th:action="@{/pettypes/__${petType.id}__/delete}" method="post" style="display:inline">
+            <button type="submit" class="btn btn-sm btn-danger"
+              onclick="return confirm('このペットタイプを削除してもよろしいですか？')">Delete</button>
+          </form>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+</body>
+
+</html>


### PR DESCRIPTION
Resolves #80. Adds a new /pettypes endpoint with full CRUD:
- PetType gains an id field and isNew() helper
- PetTypeRepository gains findById, save, delete, and isInUse
- PetTypeController handles list/create/edit/delete with validation
- Two Thymeleaf templates: petTypeList and createOrUpdatePetTypeForm
- "Pet Types" menu item added to the navigation bar
- Deletion is blocked when the type is referenced by any pet

https://claude.ai/code/session_01SV79KXDBXJo1JsAMRSHU2C