### PR TITLE
fix: use @param:Autowired to explicitly target constructor parameter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,5 +54,14 @@ Controllers detect the `HX-Request` header and return Thymeleaf fragment selecto
 ### Testing
 Tests use `@SpringBootTest(webEnvironment = RANDOM_PORT)` + `WebTestClient` + Testcontainers (PostgreSQL 16.3 via R2DBC TC URL). The test profile (`application-test.yml`) initialises the schema and seed data on startup. Use `assertThat` from AssertJ (`WithAssertions`) for assertions.
 
+**Kotlin annotation targets**: When injecting dependencies via primary constructor parameters that are also properties (`val`/`var`), always use explicit `@param:` target to avoid the annotation being applied to the backing field in future Kotlin versions ([KT-73255](https://youtrack.jetbrains.com/issue/KT-73255)):
+```kotlin
+// correct
+class MyTest(@param:Autowired private val client: WebTestClient)
+
+// wrong — generates compiler warning
+class MyTest(@Autowired private val client: WebTestClient)
+```
+
 ### Local development
 The `local` Spring profile (default) uses `spring-boot-docker-compose` to start PostgreSQL automatically from `docker-compose.yml`. No manual Docker commands needed for `bootRun`.

--- a/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/observability/PetclinicObservabilityEndToEndTests.kt
+++ b/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/observability/PetclinicObservabilityEndToEndTests.kt
@@ -55,7 +55,7 @@ import java.time.Duration
 // 実エクスポート経路を検証するため `@AutoConfigureObservability` を付与する。
 @AutoConfigureObservability
 class PetclinicObservabilityEndToEndTests(
-  @Autowired private val webTestClient: WebTestClient,
+  @param:Autowired private val webTestClient: WebTestClient,
 ) : WithAssertions {
   private fun fireApplicationRequests() {
     repeat(REQUESTS) {

--- a/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/owner/OwnerControllerIntegrationTests.kt
+++ b/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/owner/OwnerControllerIntegrationTests.kt
@@ -13,8 +13,8 @@ import org.springframework.util.LinkedMultiValueMap
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class OwnerControllerIntegrationTests(
-  @Autowired private val webTestClient: WebTestClient,
-  @Autowired private val ownerRepository: OwnerRepository,
+  @param:Autowired private val webTestClient: WebTestClient,
+  @param:Autowired private val ownerRepository: OwnerRepository,
 ) {
   @Test
   fun `should show new owner form`() {

--- a/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/pet/PetControllerIntegrationTests.kt
+++ b/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/pet/PetControllerIntegrationTests.kt
@@ -13,8 +13,8 @@ import org.springframework.util.LinkedMultiValueMap
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class PetControllerIntegrationTests(
-  @Autowired private val webTestClient: WebTestClient,
-  @Autowired private val ownerRepository: OwnerRepository,
+  @param:Autowired private val webTestClient: WebTestClient,
+  @param:Autowired private val ownerRepository: OwnerRepository,
 ) {
   @Test
   fun `should show update pet form`() {

--- a/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/visit/VisitControllerIntegrationTests.kt
+++ b/petclinic-fullstack/app/src/test/kotlin/net/yewton/petclinic/visit/VisitControllerIntegrationTests.kt
@@ -13,8 +13,8 @@ import org.springframework.util.LinkedMultiValueMap
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class VisitControllerIntegrationTests(
-  @Autowired private val webTestClient: WebTestClient,
-  @Autowired private val ownerRepository: OwnerRepository,
+  @param:Autowired private val webTestClient: WebTestClient,
+  @param:Autowired private val ownerRepository: OwnerRepository,
 ) {
   @Test
   fun `should show new visit form`() {


### PR DESCRIPTION
Kotlin will apply annotations to both value parameter and backing field
in future versions (KT-73255). Explicitly use @param: target to keep
the annotation on the constructor parameter only.

https://claude.ai/code/session_01PFTrM3h6bH5zLKMeaoqQ4y