### PR TITLE
Extract isNew() logic into Persistable interface

### DIFF
--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/model/Persistable.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/model/Persistable.kt
@@ -1,0 +1,7 @@
+package net.yewton.petclinic.model
+
+interface Persistable<ID> {
+  val id: ID?
+
+  fun isNew(): Boolean = id == null
+}

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/owner/Owner.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/owner/Owner.kt
@@ -2,11 +2,12 @@ package net.yewton.petclinic.owner
 
 import jakarta.validation.constraints.Digits
 import jakarta.validation.constraints.NotEmpty
+import net.yewton.petclinic.model.Persistable
 import net.yewton.petclinic.model.Person
 import net.yewton.petclinic.pet.Pet
 
 data class Owner(
-  val id: Int?,
+  override val id: Int?,
   @field:NotEmpty
   override val firstName: String?,
   @field:NotEmpty
@@ -19,6 +20,5 @@ data class Owner(
   @field:Digits(fraction = 0, integer = 10)
   val telephone: String?,
   val pets: Set<Pet> = emptySet(),
-) : Person {
-  fun isNew(): Boolean = id == null
-}
+) : Person,
+  Persistable<Int>

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/Pet.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/Pet.kt
@@ -1,18 +1,17 @@
 package net.yewton.petclinic.pet
 
 import jakarta.validation.constraints.NotEmpty
+import net.yewton.petclinic.model.Persistable
 import net.yewton.petclinic.visit.Visit
 import java.time.LocalDate
 
 data class Pet(
-  val id: Int?,
+  override val id: Int?,
   @field:NotEmpty
   val name: String?,
   val birthDate: LocalDate?,
   val type: PetType,
   val visits: Set<Visit> = hashSetOf(),
-) {
+) : Persistable<Int> {
   override fun toString(): String = name ?: ""
-
-  fun isNew(): Boolean = id == null
 }

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetType.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetType.kt
@@ -1,13 +1,12 @@
 package net.yewton.petclinic.pet
 
 import jakarta.validation.constraints.NotBlank
+import net.yewton.petclinic.model.Persistable
 
 data class PetType(
-  val id: Int? = null,
+  override val id: Int? = null,
   @field:NotBlank
   val name: String? = null,
-) {
+) : Persistable<Int> {
   override fun toString(): String = name ?: ""
-
-  fun isNew(): Boolean = id == null
 }

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/vet/Specialty.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/vet/Specialty.kt
@@ -1,13 +1,12 @@
 package net.yewton.petclinic.vet
 
 import jakarta.validation.constraints.NotBlank
+import net.yewton.petclinic.model.Persistable
 
 data class Specialty(
-  val id: Int? = null,
+  override val id: Int? = null,
   @field:NotBlank
   val name: String? = null,
-) {
+) : Persistable<Int> {
   override fun toString(): String = name ?: ""
-
-  fun isNew(): Boolean = id == null
 }

--- a/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/visit/Visit.kt
+++ b/petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/visit/Visit.kt
@@ -1,15 +1,14 @@
 package net.yewton.petclinic.visit
 
 import jakarta.validation.constraints.NotBlank
+import net.yewton.petclinic.model.Persistable
 import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
 
 data class Visit(
-  val id: Int? = null,
+  override val id: Int? = null,
   @field:DateTimeFormat(pattern = "yyyy-MM-dd")
   val date: LocalDate?,
   @field:NotBlank
   val description: String?,
-) {
-  fun isNew(): Boolean = id == null
-}
+) : Persistable<Int>


### PR DESCRIPTION
## 概要

複数のドメインモデル（Owner, Pet, PetType, Specialty, Visit）に個別実装されていた `fun isNew(): Boolean = id == null` を、共通インターフェース `Persistable<ID>` のデフォルト実装に集約しました。

jOOQ + R2DBC + coroutines という構成では、jOOQ 公式の `UpdatableRecord.store()` や生成 DAO はブロッキング API のため採用できません。一方、Repository ごとの insert/update 分岐は各テーブルのカラム指定や `returningResult(...).awaitSingle()` 等と密結合しており、ジェネリックな抽象 Repository でまとめるのは jOOQ の良さ（型付き API、multiset 集約取得）を損ねます。そのため、**重複している `isNew()` のみを `Persistable<ID>` でまとめる**最小スコープの改善としました。

関連 Issue: なし（設計改善のリファクタリング）

## 変更ファイル一覧と読む順序

| 順序 | ファイル | 変更種別 | 概要 |
|:---:|---|---|---|
| 1 | `petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/model/Persistable.kt` | 新規 | 永続化対象エンティティ共通の I/F。`id: ID?` と `isNew()` のデフォルト実装を提供 |
| 2 | `petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/owner/Owner.kt` | 修正 | `Persistable<Int>` を実装、`id` を `override val`、個別 `isNew()` を削除 |
| 3 | `petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/Pet.kt` | 修正 | 同上 |
| 4 | `petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetType.kt` | 修正 | 同上 |
| 5 | `petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/vet/Specialty.kt` | 修正 | 同上 |
| 6 | `petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/visit/Visit.kt` | 修正 | 同上 |

Repository 側（OwnerRepository, PetRepository, PetTypeRepository, SpecialtyRepository）の `if (entity.isNew()) insert else update` 呼び出しは無変更で動作します（メソッドシグネチャ互換）。

## クラス図

```mermaid
classDiagram
    class Persistable~ID~ {
        <<interface>>
        +id: ID?
        +isNew() Boolean
    }

    class Person {
        <<interface>>
        +firstName: String?
        +lastName: String?
    }

    class Owner {
        +id: Int?
        +address: String?
        +city: String?
        +telephone: String?
        +pets: Set~Pet~
    }

    class Pet {
        +id: Int?
        +name: String?
        +birthDate: LocalDate?
        +type: PetType
        +visits: Set~Visit~
    }

    class PetType {
        +id: Int?
        +name: String?
    }

    class Specialty {
        +id: Int?
        +name: String?
    }

    class Visit {
        +id: Int?
        +date: LocalDate?
        +description: String?
    }

    Persistable <|.. Owner
    Person <|.. Owner
    Persistable <|.. Pet
    Persistable <|.. PetType
    Persistable <|.. Specialty
    Persistable <|.. Visit
```

シーケンス図は省略（ユーザー操作・HTTP エンドポイントの変更なし）。

## 影響範囲の調査

`isNew` を参照している全箇所が新インターフェースのデフォルト実装で同一の挙動になることを確認しました。

```
$ grep -rn "isNew" petclinic-fullstack/app/src/ --include="*.kt"
petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/owner/OwnerRepository.kt:124:    if (owner.isNew()) {
petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetRepository.kt:30:     if (pet.isNew()) {
petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetController.kt:45:     ... pet.isNew() ...
petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/pet/PetTypeRepository.kt:48: if (petType.isNew()) {
petclinic-fullstack/app/src/main/kotlin/net/yewton/petclinic/vet/SpecialtyRepository.kt:48: if (specialty.isNew()) {
```

呼び出し側は `entity.isNew()` のままで型推論によりデフォルト実装に解決されます。

## レビュー観点と私の原案

### 1. なぜジェネリック型抽象 Repository (`AbstractCrudRepository<E, R, ID>`) まで踏み込まないのか

**原案：今は採用しない。理由を残しつつ将来の選択肢として保留。**

- Repository の `insert` 文は各テーブルのカラム指定・`returningResult(ID).awaitSingle()` を持ち、jOOQ の型付き API と密結合している。共通化のメリット（数行の `if-else` 削減）に対し、抽象化のコスト（`toRecord`/`fromRecord` の bridge、各 Repository が抽象クラスにロックインされる）が見合わない。
- 特に OwnerRepository は `multiset` で Pet + Visit を一括取得する jOOQ らしいクエリを持つため、汎用 CRUD 抽象は適合しない。
- jOOQ 公式ブログでも、Spring Data 流の汎用 CRUD を jOOQ に被せることは推奨されていない（Repository は「クエリを書く場所」と位置づけられる）。

### 2. `Persistable<ID>` のジェネリック化は必要か

**原案：必要。現状全エンティティが `Int` でも、ジェネリック化のコストはゼロに近い。**

- 将来 UUID 等の他 ID 型が現れたときに I/F 変更不要。
- `isNew()` のデフォルト実装は `id == null` のみで型に依存せず、ジェネリック化による落とし穴はない。

### 3. jOOQ 標準の `UpdatableRecord.store()` を採用しなかった理由

**原案：採用不可。R2DBC + coroutines と非互換。**

- `UpdatableRecord.store()` および生成 DAO はブロッキング API。本プロジェクトの非ブロッキング規約に違反する。
- jOOQ の R2DBC サポートは `ctx.insertInto(...).execute()` を Publisher として返すレベルで、`store()` の reactive 版は提供されない。
- したがって「jOOQ デファクトは UpdatableRecord」だが、本プロジェクト固有制約から `Persistable` で代替するのが妥当。

## 動作確認

- `./gradlew spotlessApply` ✅
- `./gradlew compileKotlin` ✅（コンパイル・ktlint パス）
- `./gradlew check` のテストはローカル環境の Docker 不在で Testcontainers 起動不可だったため、CI に委ねます。

https://claude.ai/code/session_01GiSoAVpb21jTN71Hk5KXbx