### PR TITLE
feat: add Render PR preview environment setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+.gradle/
+references/
+**/build/
+**/.DS_Store
+**/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# petclinic
+
+Spring Boot + Kotlin + R2DBC による Pet Clinic アプリケーション。`fullstack-html`（プレーン HTML）と `fullstack-htmx`（HTMX）の 2 つのアプリを含む。
+
+## PR プレビュー環境
+
+[Render](https://render.com) の Blueprint を使い、PR ごとに両アプリを自動デプロイする。
+
+### セットアップ手順
+
+1. Render アカウントを作成（無料、クレカ不要）
+2. **Blueprints** → **New Blueprint Instance** を選択
+3. このリポジトリ（`yewton/petclinic`）を接続
+4. `render.yaml` が自動検出される → **Apply** をクリック
+5. 初回に **primary サービス**（petclinic-html / petclinic-htmx）と **primary DB**（petclinic-db）が作成される
+   - `autoDeploy: false` のため main ブランチへのプッシュでは自動デプロイされない
+   - primary サービスは放置で構わない
+
+以降は PR を open するたびに Render が自動でプレビュー環境を作成し、PR にコメントで URL を投稿する。
+
+### プレビュー環境の構成
+
+PR ごとに以下が作成される:
+
+| リソース | 内容 |
+|----------|------|
+| `petclinic-html` (preview) | プレーン HTML 版 Web Service |
+| `petclinic-htmx` (preview) | HTMX 版 Web Service |
+| `petclinic-db` (preview) | PostgreSQL（スキーマ・シードデータ自動投入） |
+
+PR をクローズすると、これらのリソースは自動削除される。7 日間非活動でも自動削除される（`expireAfterDays: 7`）。
+
+### 注意事項
+
+#### コールドスタート
+
+Render Free の Web Service は **15 分間アクセスがないとスピンダウン**する。次のアクセス時に再起動が走り、**約 1 〜 2 分かかる**。最初のリクエストがタイムアウトに見えても、しばらく待ってからリロードすること。
+
+#### Docker ビルド時間
+
+プレビュー環境の初回ビルドは Gradle 依存関係のダウンロードを含むため、**5〜10 分程度かかる**場合がある。
+
+#### Free Postgres の同時数制限
+
+Render Free Postgres は **ワークスペースあたり 1 つまで**という制限がある可能性がある。複数 PR を同時に open すると 2 つ目以降の DB 作成が失敗するケースが報告されている。
+
+この問題が発生した場合の対応案:
+
+- **案 A**: 共有 DB に PR 番号でスキーマを分ける
+- **案 B**: [Neon](https://neon.tech) に切り替える（無料枠あり、DB ブランチ機能で PR ごとに隔離 DB を作れる）
+
+同時に複数 PR を open してみて問題が起きた場合は、どちらの案を採用するか判断する。
+
+#### 本番デプロイについて
+
+`render.yaml` で定義された primary サービスは `autoDeploy: false` のため、main ブランチをプッシュしても自動デプロイされない。本番デプロイが必要になった場合は render.yaml を修正すること。
+
+## ローカル開発
+
+```bash
+# プレーンHTML版を起動（Docker Compose で PostgreSQL が自動起動する）
+./gradlew :fullstack-html:app:bootRun
+
+# HTMX版を起動
+./gradlew :fullstack-htmx:app:bootRun
+```
+
+## ビルドとテスト
+
+```bash
+# フォーマット適用
+./gradlew spotlessApply
+
+# ビルド・テスト（CI と同じコマンド）
+./gradlew check --parallel --warning-mode all --build-cache --configuration-cache
+
+# ローカルで Docker イメージを作成（Cloud Native Buildpacks 使用）
+./gradlew :fullstack-html:app:bootBuildImage
+./gradlew :fullstack-htmx:app:bootBuildImage
+```

--- a/build-logic/spring-boot/src/main/kotlin/net.yewton.petclinic.spring-boot-app.gradle.kts
+++ b/build-logic/spring-boot/src/main/kotlin/net.yewton.petclinic.spring-boot-app.gradle.kts
@@ -16,3 +16,10 @@ tasks.processResources {
     )
   }
 }
+
+// https://docs.spring.io/spring-boot/reference/packaging/container-images/efficient-images.html
+tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootBuildImage>().configureEach {
+  imageName = "net.yewton.petclinic/${project.parent?.name ?: project.name}"
+  environment.put("BP_JVM_VERSION", "21")
+  environment.put("BP_JVM_CDS_ENABLED", "true")
+}

--- a/fullstack-html/Dockerfile
+++ b/fullstack-html/Dockerfile
@@ -1,0 +1,21 @@
+FROM eclipse-temurin:21-jdk-noble AS build
+WORKDIR /workspace
+COPY . .
+RUN chmod +x gradlew && \
+    ./gradlew :fullstack-html:app:bootJar --no-daemon -x test
+
+FROM eclipse-temurin:21-jre-noble AS extract
+WORKDIR /layers
+COPY --from=build /workspace/fullstack-html/app/build/libs/*.jar app.jar
+RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+
+FROM eclipse-temurin:21-jre-noble
+RUN groupadd --system spring && useradd --system --gid spring --no-create-home spring
+WORKDIR /app
+COPY --from=extract /layers/extracted/dependencies/ ./
+COPY --from=extract /layers/extracted/spring-boot-loader/ ./
+COPY --from=extract /layers/extracted/snapshot-dependencies/ ./
+COPY --from=extract /layers/extracted/application/ ./
+RUN chown -R spring:spring /app
+USER spring:spring
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/fullstack-html/app/src/main/resources/application-render.yml
+++ b/fullstack-html/app/src/main/resources/application-render.yml
@@ -1,0 +1,10 @@
+spring:
+  r2dbc:
+    url: r2dbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT:5432}/${POSTGRES_DB}
+    pool:
+      max-size: 5
+  sql:
+    init:
+      schema-locations: classpath:db/schema.sql
+      data-locations: classpath:db/data.sql
+      mode: always

--- a/fullstack-htmx/Dockerfile
+++ b/fullstack-htmx/Dockerfile
@@ -1,0 +1,21 @@
+FROM eclipse-temurin:21-jdk-noble AS build
+WORKDIR /workspace
+COPY . .
+RUN chmod +x gradlew && \
+    ./gradlew :fullstack-htmx:app:bootJar --no-daemon -x test
+
+FROM eclipse-temurin:21-jre-noble AS extract
+WORKDIR /layers
+COPY --from=build /workspace/fullstack-htmx/app/build/libs/*.jar app.jar
+RUN java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
+
+FROM eclipse-temurin:21-jre-noble
+RUN groupadd --system spring && useradd --system --gid spring --no-create-home spring
+WORKDIR /app
+COPY --from=extract /layers/extracted/dependencies/ ./
+COPY --from=extract /layers/extracted/spring-boot-loader/ ./
+COPY --from=extract /layers/extracted/snapshot-dependencies/ ./
+COPY --from=extract /layers/extracted/application/ ./
+RUN chown -R spring:spring /app
+USER spring:spring
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/fullstack-htmx/app/src/main/resources/application-render.yml
+++ b/fullstack-htmx/app/src/main/resources/application-render.yml
@@ -1,0 +1,10 @@
+spring:
+  r2dbc:
+    url: r2dbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT:5432}/${POSTGRES_DB}
+    pool:
+      max-size: 5
+  sql:
+    init:
+      schema-locations: classpath:db/schema.sql
+      data-locations: classpath:db/data.sql
+      mode: always

--- a/render.yaml
+++ b/render.yaml
@@ -7,7 +7,6 @@ databases:
     databaseName: petclinic
     user: petclinic
     plan: free
-    previewPlan: free
 
 services:
   - type: web

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,77 @@
+previews:
+  generation: automatic
+  expireAfterDays: 7
+
+databases:
+  - name: petclinic-db
+    databaseName: petclinic
+    user: petclinic
+    plan: free
+    previewPlan: free
+
+services:
+  - type: web
+    name: petclinic-html
+    runtime: docker
+    dockerfilePath: fullstack-html/Dockerfile
+    plan: free
+    autoDeploy: false
+    healthCheckPath: /actuator/health
+    envVars:
+      - key: SPRING_PROFILES_ACTIVE
+        value: render
+      - key: POSTGRES_HOST
+        fromDatabase:
+          name: petclinic-db
+          property: host
+      - key: POSTGRES_PORT
+        fromDatabase:
+          name: petclinic-db
+          property: port
+      - key: POSTGRES_DB
+        fromDatabase:
+          name: petclinic-db
+          property: database
+      - key: POSTGRES_USER
+        fromDatabase:
+          name: petclinic-db
+          property: user
+      - key: POSTGRES_PASS
+        fromDatabase:
+          name: petclinic-db
+          property: password
+      - key: JAVA_TOOL_OPTIONS
+        value: "-Xmx400m -XX:+UseSerialGC"
+
+  - type: web
+    name: petclinic-htmx
+    runtime: docker
+    dockerfilePath: fullstack-htmx/Dockerfile
+    plan: free
+    autoDeploy: false
+    healthCheckPath: /actuator/health
+    envVars:
+      - key: SPRING_PROFILES_ACTIVE
+        value: render
+      - key: POSTGRES_HOST
+        fromDatabase:
+          name: petclinic-db
+          property: host
+      - key: POSTGRES_PORT
+        fromDatabase:
+          name: petclinic-db
+          property: port
+      - key: POSTGRES_DB
+        fromDatabase:
+          name: petclinic-db
+          property: database
+      - key: POSTGRES_USER
+        fromDatabase:
+          name: petclinic-db
+          property: user
+      - key: POSTGRES_PASS
+        fromDatabase:
+          name: petclinic-db
+          property: password
+      - key: JAVA_TOOL_OPTIONS
+        value: "-Xmx400m -XX:+UseSerialGC"


### PR DESCRIPTION
- render.yaml: Blueprint で PR ごとに fullstack-html/fullstack-htmx と PostgreSQL を自動デプロイ
  - previews.generation: automatic + expireAfterDays: 7 でプレビューを自動管理
  - databases.previewPlan: free で PR ごとに DB を作成
  - fromDatabase でホスト/ポート/DB名/認証情報を各サービスに注入
  - autoDeploy: false でメインブランチへの自動デプロイを無効化
- Dockerfile: 各アプリの 3 ステージ Dockerfile（build/extract/runtime）
  - Spring Boot layered JAR（-Djarmode=tools extract --layers）で依存とアプリをレイヤー分離
  - eclipse-temurin:21-jre-noble を実行イメージに使用（Render は Java ネイティブ非対応）
- application-render.yml: render プロファイルで R2DBC URL を個別環境変数から組み立て、コネクションプールを制限
- spring-boot-app.gradle.kts: bootBuildImage に BP_JVM_CDS_ENABLED=true を設定（ローカル用）
- .dockerignore: .git・references・build ディレクトリを除外してビルドコンテキストを軽量化
- README.md: セットアップ手順・コールドスタート・Free DB 数制限の注意点を記載

https://claude.ai/code/session_01R8NrpMTfS5iT5PqzjnXXui